### PR TITLE
Remove option to clone repo directly from target

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ NI-ELVIS-III-Python-Examples supports Python 2.7, 3.4+.
   * [Configuring the NI ELVIS III Device](#configuring-the-ni-elvis-iii-device)
   * [Installing Prerequisite Software for NI ELVIS III Python](#installing-prerequisite-software-for-ni-elvis-iii-python)
   * [Installing NI ELVIS III Python Examples](#installing-ni-elvis-iii-python-examples)
-    + [Option 1 - Cloning from GitHub on the Device](#option-1---cloning-from-github-on-the-device)
-    + [Option 2 - Download ZIP File and Upload to the Device via SFTP](#option-2---download-zip-file-and-upload-to-the-device-via-sftp)
+    + [Download ZIP File and Upload to the Device via SFTP](#download-zip-file-and-upload-to-the-device-via-sftp)
 - [Running the Example](#running-the-example)
 - [Examples Overview](#examples-overview)
   * [Analog](#analog)
@@ -93,26 +92,9 @@ In this section we will install the software needed to execute the NI ELVIS III 
 
 ## Installing NI ELVIS III Python Examples 
 
-In this section we will download the NI ELVIS III Python Examples. You are free to choose any option you are comfortable with to install NI ELVIS III Python Examples.
+In this section we will download the NI ELVIS III Python Examples. 
 
-### Option 1 - Cloning from GitHub on the Device
-
-1. Open PuTTY, install `git` on the NI ELVIS III device.
-
-   ```
-   opkg install git
-   ```
-2. Download the NI ELVIS III Python helper library and Python Example from GitHub.
-   - Download NI ELVIS III Python.
-   
-     ```
-     git clone https://github.com/ni/NI-ELVIS-III-Python-Examples.git
-     ```
-   - You can now find **NI-ELVIS-III-Python-Examples** in your current directory. The default directory is `/home/admin`.
-
-<p align="right"><a href="#top">↥ back to top</a>
-
-### Option 2 - Download ZIP File and Upload to the Device via SFTP
+### Download ZIP File and Upload to the Device via SFTP
 
 1. Open the [NI ELVIS III Python Examples](https://github.com/ni/NI-ELVIS-III-Python-Examples) on GitHub.
 2. Download the NI ELVIS III Python helper library and Python Examples from GitHub and upzip it.


### PR DESCRIPTION
The 'git' package is missing in the 19.0 release for ARM targets. The option to clone directly from the target should be removed until the 'git' package is added back.